### PR TITLE
support flutter-1.12.13 | dart-2.7 | androidX

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -47,7 +47,7 @@ android {
         targetSdkVersion 28
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 
     signingConfigs {
@@ -77,6 +77,6 @@ flutter {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'com.android.support.test:runner:1.0.2'
-    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    androidTestImplementation 'androidx.test:runner:1.1.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.1.0'
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,2 +1,4 @@
 org.gradle.jvmargs=-Xmx1536M
 android.enableR8=true
+android.useAndroidX=true
+android.enableJetifier=true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   http: ^0.12.0
   shared_preferences: ^0.5.4+5
   url_launcher: ^5.2.5
-  cached_network_image: ^1.1.3 # https://pub.dartlang.org/packages/cached_network_image
+  cached_network_image: ^2.0.0-rc.1 # https://pub.dartlang.org/packages/cached_network_image
   html: ^0.14.0+3 # https://pub.flutter-io.cn/packages/html
   xpath: ^0.1.0 # https://pub.flutter-io.cn/packages/xpath     还不支持 ETree.toString(Element) :(
   dio: ^3.0.5 # https://pub.dartlang.org/packages/dio
@@ -47,12 +47,12 @@ dependencies:
   # flutter_whatsnew 目前存在问题，fork 后修改源码了
   flutter_markdown: ^0.2.0
   shimmer: ^1.0.1
-  zefyr: ^0.8.0 # https://pub.dartlang.org/packages/zefyr#-installing-tab-
-  #    zefyr:
-  #      git:
-  #        url: https://github.com/memspace/zefyr.git
-  #        ref: dev
-  #        path: packages/zefyr
+#  zefyr: ^0.8.0 # https://pub.dartlang.org/packages/zefyr#-installing-tab-
+  zefyr:
+    git:
+      url: git://github.com/memspace/zefyr.git
+      ref: fix-text-input-connection-closed
+      path: packages/zefyr
   photo_view: ^0.4.2
   # webview_flutter: ^0.3.6 无法弹出键盘输入的问题还没解决
   flutter_webview_plugin: ^0.3.8


### PR DESCRIPTION
support flutter-1.12.13 | dart-2.7 | androidX  
 - update zefyr & cached_network_image
 - use AndroidX instead of Android-Support